### PR TITLE
Some improvements for the Coprocessor cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#98f910b71904ff7190e26a483b242ad5d7330c31"
+source = "git+https://github.com/innerr/kvproto.git?branch=issue-6690#ede0eca141e699ba675a10b248ae458fd7e94c1c"
 dependencies = [
  "futures 0.1.29",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ openssl = "0.10"
 tokio-openssl = "0.2"
 hyper = { version = "0.12", default-features = false, features = ["runtime"] }
 keys = { path = "components/keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 lazy_static = "1.3"
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -63,7 +63,7 @@ futures-cpupool = "0.1"
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../components/keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 nix = "0.11"

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -52,7 +52,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io", "i
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 lazy_static = "1.3"
 prometheus = { version = "0.8", default-features = false, features = ["nightly", "push", "process"] }
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -163,6 +163,7 @@ impl BackupRange {
             IsolationLevel::Si,
             false, /* fill_cache */
             Default::default(),
+            false,
         );
         let start_key = self.start_key.clone();
         let end_key = self.end_key.clone();

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -253,9 +253,10 @@ impl TestSuite {
             IsolationLevel::Si,
             false,
             Default::default(),
+            false,
         );
         let mut scanner = RangesScanner::new(RangesScannerOptions {
-            storage: TiKVStorage::from(snap_store),
+            storage: TiKVStorage::new(snap_store, false),
             ranges: vec![Range::Interval(IntervalRange::from((start, end)))],
             scan_backward_in_range: false,
             is_key_only: false,

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -38,7 +38,7 @@ engine_rocks = { path = "../engine_rocks" }
 failure = "0.1"
 futures = "0.1"
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 pd_client = { path = "../pd_client" }
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "../raftstore" }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -14,7 +14,7 @@ crc32fast = "1.2"
 engine_traits = { path = "../engine_traits" }
 failure = "0.1"
 hex = "0.4.2"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 openssl = "0.10"
 protobuf = "2.8"
 rand = "0.7"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -43,6 +43,6 @@ git = "https://github.com/tikv/rust-prometheus.git"
 rev = "a626d449eaebd5e8ce337f95c1d6dc9800f25df7"
 
 [dev-dependencies]
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 tempfile = "3.0"
 rand = "0.7"

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.1"
 futures-executor = "0.3"
 futures-io = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 rand = "0.7"
 rusoto_core = "0.43.0"
 rusoto_s3 = "0.43.0"

--- a/components/into_other/Cargo.toml
+++ b/components/into_other/Cargo.toml
@@ -10,5 +10,5 @@ prost-codec = ["kvproto/prost-codec", "raft/prost-codec"]
 
 [dependencies]
 engine_traits = { path = "../engine_traits" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.2"
 derive_more = "0.99.3"
 failure = "0.1"
 hex = "0.4"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 tikv_alloc = { path = "../tikv_alloc" }
 
 [dev-dependencies]

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -20,7 +20,7 @@ prost-codec = [
 futures = "0.1"
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 prometheus = { version = "0.8", features = ["nightly", "push", "process"] }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = { version = "0.3.1", default-features = false, features = ["io"] 
 hex = "0.4"
 into_other = { path = "../into_other" }
 keys = { path = "../keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 lazy_static = "1.3"
 prometheus = { version = "0.8", default-features = false }
 quick-error = "1.2.2"

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -24,7 +24,7 @@ prost-codec = [
 
 [dependencies]
 futures = "0.1"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 protobuf = "2"
 test_storage = { path = "../test_storage" }
 tidb_query_datatype = { path = "../tidb_query_datatype" }

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -210,6 +210,7 @@ impl<E: Engine> Store<E> {
             IsolationLevel::Si,
             true,
             Default::default(),
+            false,
         )
     }
 

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -35,7 +35,7 @@ futures-cpupool = "0.1"
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 pd_client = { path = "../pd_client" }
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "../raftstore" }

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -26,5 +26,5 @@ engine = { path = "../engine" }
 engine_rocks = { path = "../engine_rocks" }
 engine_traits = { path = "../engine_traits" }
 keys = { path = "../keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -22,7 +22,7 @@ prost-codec = [
 
 [dependencies]
 futures = "0.1"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 raftstore = { path = "../raftstore" }
 test_raftstore = { path = "../test_raftstore" }
 tikv = { path = "../../", default-features = false }

--- a/components/tidb_query_common/Cargo.toml
+++ b/components/tidb_query_common/Cargo.toml
@@ -13,7 +13,7 @@ failure = "0.1"
 derive_more = "0.15.0"
 tikv_util = { path = "../tikv_util" }
 #tidb_query_datatype = { path = "../tidb_query_datatype" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 prometheus = { version = "0.8", features = ["nightly", "push", "process"] }
 lazy_static = "1.3"

--- a/components/tidb_query_common/src/storage/mod.rs
+++ b/components/tidb_query_common/src/storage/mod.rs
@@ -31,7 +31,7 @@ pub trait Storage: Send {
     // TODO: Use reference is better.
     fn get(&mut self, is_key_only: bool, range: PointRange) -> Result<Option<OwnedKvPair>>;
 
-    fn can_be_cached(&mut self) -> bool;
+    fn met_uncacheable_data(&self) -> Option<bool>;
 
     fn collect_statistics(&mut self, dest: &mut Self::Statistics);
 }
@@ -56,8 +56,8 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         (**self).get(is_key_only, range)
     }
 
-    fn can_be_cached(&mut self) -> bool {
-        (**self).can_be_cached()
+    fn met_uncacheable_data(&self) -> Option<bool> {
+        (**self).met_uncacheable_data()
     }
 
     fn collect_statistics(&mut self, dest: &mut Self::Statistics) {

--- a/components/tidb_query_common/src/storage/scanner.rs
+++ b/components/tidb_query_common/src/storage/scanner.rs
@@ -153,8 +153,9 @@ impl<T: Storage> RangesScanner<T> {
         range
     }
 
-    pub fn can_be_cached(&mut self) -> bool {
-        self.storage.can_be_cached()
+    #[inline]
+    pub fn can_be_cached(&self) -> bool {
+        self.storage.met_uncacheable_data() == Some(false)
     }
 
     fn update_scanned_range_from_new_point(&mut self, point: &PointRange) {

--- a/components/tidb_query_common/src/storage/test_fixture.rs
+++ b/components/tidb_query_common/src/storage/test_fixture.rs
@@ -104,8 +104,8 @@ impl super::Storage for FixtureStorage {
 
     fn collect_statistics(&mut self, _dest: &mut Self::Statistics) {}
 
-    fn can_be_cached(&mut self) -> bool {
-        true
+    fn met_uncacheable_data(&self) -> Option<bool> {
+        None
     }
 }
 

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -24,7 +24,7 @@ chrono-tz = "0.5.1"
 codec = { path = "../codec" }
 failure = "0.1"
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 lazy_static = "1.3"
 match_template = { path = "../match_template" }
 nom = { version = "5.1.0", default-features = false, features = ["std"] }

--- a/components/tidb_query_normal_executors/Cargo.toml
+++ b/components/tidb_query_normal_executors/Cargo.toml
@@ -10,7 +10,7 @@ byteorder = "1.2"
 codec = { path = "../codec" }
 failure = "0.1"
 indexmap = { version = "1.0", features = ["serde-1"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 protobuf = "2"
 tidb_query_datatype = { path = "../tidb_query_datatype" }
 tidb_query_common = { path = "../tidb_query_common" }

--- a/components/tidb_query_normal_executors/src/aggregation.rs
+++ b/components/tidb_query_normal_executors/src/aggregation.rs
@@ -149,7 +149,7 @@ impl<Src: Executor> AggExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.src.can_be_cached()
     }
 }
@@ -270,7 +270,7 @@ impl<Src: Executor> Executor for HashAggExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.inner.can_be_cached()
     }
 }
@@ -334,7 +334,7 @@ impl<Src: Executor> Executor for StreamAggExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.inner.can_be_cached()
     }
 }

--- a/components/tidb_query_normal_executors/src/lib.rs
+++ b/components/tidb_query_normal_executors/src/lib.rs
@@ -284,7 +284,7 @@ pub trait Executor: Send {
 
     fn take_scanned_range(&mut self) -> IntervalRange;
 
-    fn can_be_cached(&mut self) -> bool;
+    fn can_be_cached(&self) -> bool;
 
     fn with_summary_collector<C: ExecSummaryCollector>(
         self,
@@ -341,7 +341,7 @@ impl<C: ExecSummaryCollector + Send, T: Executor> Executor for WithSummaryCollec
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.inner.can_be_cached()
     }
 }
@@ -380,7 +380,7 @@ impl<T: Executor + ?Sized> Executor for Box<T> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         (**self).can_be_cached()
     }
 }

--- a/components/tidb_query_normal_executors/src/limit.rs
+++ b/components/tidb_query_normal_executors/src/limit.rs
@@ -66,7 +66,7 @@ impl<Src: Executor> Executor for LimitExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.src.can_be_cached()
     }
 }

--- a/components/tidb_query_normal_executors/src/runner.rs
+++ b/components/tidb_query_normal_executors/src/runner.rs
@@ -319,7 +319,7 @@ impl<SS: 'static> ExecutorsRunner<SS> {
     }
 
     #[inline]
-    pub fn can_be_cached(&mut self) -> bool {
+    pub fn can_be_cached(&self) -> bool {
         self.executor.can_be_cached()
     }
 }

--- a/components/tidb_query_normal_executors/src/scan.rs
+++ b/components/tidb_query_normal_executors/src/scan.rs
@@ -124,7 +124,7 @@ impl<S: Storage, T: InnerExecutor> Executor for ScanExecutor<S, T> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.scanner.can_be_cached()
     }
 }

--- a/components/tidb_query_normal_executors/src/selection.rs
+++ b/components/tidb_query_normal_executors/src/selection.rs
@@ -82,7 +82,7 @@ impl<Src: Executor> Executor for SelectionExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.src.can_be_cached()
     }
 }

--- a/components/tidb_query_normal_executors/src/topn.rs
+++ b/components/tidb_query_normal_executors/src/topn.rs
@@ -149,7 +149,7 @@ impl<Src: Executor> Executor for TopNExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.src.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/Cargo.toml
+++ b/components/tidb_query_vec_executors/Cargo.toml
@@ -8,7 +8,7 @@ description = "A vector query engine to run TiDB pushed down executors"
 [dependencies]
 codec = { path = "../codec" }
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 match_template = { path = "../match_template" }
 servo_arc = "0.1.1"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/tidb_query_vec_executors/src/fast_hash_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/fast_hash_aggr_executor.rs
@@ -65,7 +65,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchFastHashAggregationExecutor<Src>
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.0.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_vec_executors/src/index_scan_executor.rs
@@ -111,7 +111,7 @@ impl<S: Storage> BatchExecutor for BatchIndexScanExecutor<S> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.0.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/interface.rs
+++ b/components/tidb_query_vec_executors/src/interface.rs
@@ -50,7 +50,7 @@ pub trait BatchExecutor: Send {
 
     fn take_scanned_range(&mut self) -> IntervalRange;
 
-    fn can_be_cached(&mut self) -> bool;
+    fn can_be_cached(&self) -> bool;
 
     fn collect_summary(
         self,
@@ -89,7 +89,7 @@ impl<T: BatchExecutor + ?Sized> BatchExecutor for Box<T> {
         (**self).take_scanned_range()
     }
 
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         (**self).can_be_cached()
     }
 }
@@ -125,7 +125,7 @@ impl<C: ExecSummaryCollector + Send, T: BatchExecutor> BatchExecutor
         self.inner.take_scanned_range()
     }
 
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.inner.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/limit_executor.rs
+++ b/components/tidb_query_vec_executors/src/limit_executor.rs
@@ -61,7 +61,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchLimitExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.src.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/runner.rs
+++ b/components/tidb_query_vec_executors/src/runner.rs
@@ -476,7 +476,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         self.out_most_executor.collect_storage_stats(dest);
     }
 
-    pub fn can_be_cached(&mut self) -> bool {
+    pub fn can_be_cached(&self) -> bool {
         self.out_most_executor.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/selection_executor.rs
+++ b/components/tidb_query_vec_executors/src/selection_executor.rs
@@ -201,7 +201,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.src.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/simple_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/simple_aggr_executor.rs
@@ -51,7 +51,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSimpleAggregationExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.0.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
@@ -61,7 +61,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSlowHashAggregationExecutor<Src>
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.0.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/stream_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/stream_aggr_executor.rs
@@ -52,7 +52,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchStreamAggregationExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.0.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_vec_executors/src/table_scan_executor.rs
@@ -118,7 +118,7 @@ impl<S: Storage> BatchExecutor for BatchTableScanExecutor<S> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.0.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/top_n_executor.rs
+++ b/components/tidb_query_vec_executors/src/top_n_executor.rs
@@ -350,7 +350,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchTopNExecutor<Src> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.src.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/util/aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/util/aggr_executor.rs
@@ -322,7 +322,7 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> BatchExecutor
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.entities.src.can_be_cached()
     }
 }

--- a/components/tidb_query_vec_executors/src/util/mock_executor.rs
+++ b/components/tidb_query_vec_executors/src/util/mock_executor.rs
@@ -48,7 +48,7 @@ impl BatchExecutor for MockExecutor {
         unreachable!()
     }
 
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         false
     }
 }

--- a/components/tidb_query_vec_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_vec_executors/src/util/scan_executor.rs
@@ -207,7 +207,7 @@ impl<S: Storage, I: ScanExecutorImpl> BatchExecutor for ScanExecutor<S, I> {
     }
 
     #[inline]
-    fn can_be_cached(&mut self) -> bool {
+    fn can_be_cached(&self) -> bool {
         self.scanner.can_be_cached()
     }
 }

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -14,7 +14,7 @@ farmhash = "1.1.5"
 hex = "0.4"
 derive-new = "0.5"
 codec = { path = "../codec" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 slog = "2.3"
 quick-error = "1.2.2"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -91,10 +91,9 @@ impl Key {
 
     /// Creates a new key by appending a `u64` timestamp to this key.
     #[inline]
-    pub fn append_ts(self, ts: TimeStamp) -> Key {
-        let mut encoded = self.0;
-        encoded.encode_u64_desc(ts.into_inner()).unwrap();
-        Key(encoded)
+    pub fn append_ts(mut self, ts: TimeStamp) -> Key {
+        self.0.encode_u64_desc(ts.into_inner()).unwrap();
+        self
     }
 
     /// Gets the timestamp contained in this key.

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -31,9 +31,10 @@ impl<S: Snapshot> ChecksumContext<S> {
             req_ctx.context.get_isolation_level(),
             !req_ctx.context.get_not_fill_cache(),
             req_ctx.bypass_locks.clone(),
+            false,
         );
         let scanner = RangesScanner::new(RangesScannerOptions {
-            storage: store.into(),
+            storage: TiKVStorage::new(store, false),
             ranges: ranges
                 .into_iter()
                 .map(|r| Range::from_pb_range(r, false))

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -204,6 +204,7 @@ impl<E: Engine> Endpoint<E> {
                         req_ctx.context.get_isolation_level(),
                         !req_ctx.context.get_not_fill_cache(),
                         req_ctx.bypass_locks.clone(),
+                        req.get_is_cache_enabled(),
                     );
                     dag::DagHandlerBuilder::new(
                         dag,

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -41,10 +41,11 @@ impl<S: Snapshot> AnalyzeContext<S> {
             req_ctx.context.get_isolation_level(),
             !req_ctx.context.get_not_fill_cache(),
             req_ctx.bypass_locks.clone(),
+            false,
         );
         Ok(Self {
             req,
-            storage: Some(store.into()),
+            storage: Some(TiKVStorage::new(store, false)),
             ranges,
             storage_stats: Statistics::default(),
         })

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -250,6 +250,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                         ctx.get_isolation_level(),
                         !ctx.get_not_fill_cache(),
                         bypass_locks,
+                        false,
                     );
                     let result = snap_store
                         .get(&key, &mut statistics)
@@ -302,6 +303,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                         ctx.get_isolation_level(),
                         !ctx.get_not_fill_cache(),
                         Default::default(),
+                        false,
                     );
                     let mut results = vec![];
                     // TODO: optimize using seek.
@@ -358,6 +360,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                         ctx.get_isolation_level(),
                         !ctx.get_not_fill_cache(),
                         bypass_locks,
+                        false,
                     );
                     let result = snap_store
                         .batch_get(&keys, &mut statistics)
@@ -428,6 +431,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                         ctx.get_isolation_level(),
                         !ctx.get_not_fill_cache(),
                         bypass_locks,
+                        false,
                     );
 
                     let mut scanner;

--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -8,3 +8,10 @@ pub use self::point_getter::{PointGetter, PointGetterBuilder};
 pub use self::reader::{check_need_gc, MvccReader};
 pub use self::scanner::test_util;
 pub use self::scanner::{has_data_in_range, DeltaScanner, EntryScanner, Scanner, ScannerBuilder};
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum NewerTsCheckState {
+    Unknown,
+    Met,
+    NotMetYet,
+}

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -366,7 +366,8 @@ mod tests {
         expected_met_newer_ts_data: bool,
     ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut point_getter = PointGetterBuilder::new(snapshot, getter_ts.into())
+        let ts = getter_ts.into();
+        let mut point_getter = PointGetterBuilder::new(snapshot.clone(), ts)
             .isolation_level(IsolationLevel::Si)
             .check_has_newer_ts_data(true)
             .build()
@@ -379,6 +380,15 @@ mod tests {
             NewerTsCheckState::NotMetYet
         };
         assert_eq!(expected, point_getter.met_newer_ts_data());
+
+        let mut point_getter = PointGetterBuilder::new(snapshot, ts)
+            .isolation_level(IsolationLevel::Si)
+            .check_has_newer_ts_data(false)
+            .build()
+            .unwrap();
+        let val = point_getter.get(&Key::from_raw(key)).unwrap().unwrap();
+        assert_eq!(val, value);
+        assert_eq!(NewerTsCheckState::Unknown, point_getter.met_newer_ts_data());
     }
 
     fn must_get_none<S: Snapshot>(point_getter: &mut PointGetter<S>, key: &[u8]) {

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -8,7 +8,7 @@ use txn_types::{Key, Lock, TimeStamp, Value, Write, WriteRef, WriteType};
 
 use super::ScannerConfig;
 use crate::storage::kv::{Cursor, Snapshot, Statistics, SEEK_BOUND};
-use crate::storage::mvcc::{Error, Result};
+use crate::storage::mvcc::{Error, NewerTsCheckState, Result};
 
 // When there are many versions for the user key, after several tries,
 // we will use seek to locate the right position. But this will turn around
@@ -34,7 +34,7 @@ pub struct BackwardKvScanner<S: Snapshot> {
     /// Is iteration started
     is_started: bool,
     statistics: Statistics,
-    can_be_cached: bool,
+    met_newer_ts_data: NewerTsCheckState,
 }
 
 impl<S: Snapshot> BackwardKvScanner<S> {
@@ -43,15 +43,18 @@ impl<S: Snapshot> BackwardKvScanner<S> {
         lock_cursor: Cursor<S::Iter>,
         write_cursor: Cursor<S::Iter>,
     ) -> BackwardKvScanner<S> {
-        let can_be_cached = cfg.check_can_be_cached;
         BackwardKvScanner {
+            met_newer_ts_data: if cfg.check_has_newer_ts_data {
+                NewerTsCheckState::NotMetYet
+            } else {
+                NewerTsCheckState::Unknown
+            },
             cfg,
             lock_cursor,
             write_cursor,
             statistics: Statistics::default(),
             default_cursor: None,
             is_started: false,
-            can_be_cached,
         }
     }
 
@@ -60,8 +63,11 @@ impl<S: Snapshot> BackwardKvScanner<S> {
         std::mem::replace(&mut self.statistics, Statistics::default())
     }
 
-    pub fn can_be_cached(&mut self) -> bool {
-        self.cfg.check_can_be_cached && self.can_be_cached
+    /// Whether we met newer ts data.
+    /// The result is always `Unknown` if `check_has_newer_ts_data` is not set.
+    #[inline]
+    pub fn met_newer_ts_data(&self) -> NewerTsCheckState {
+        self.met_newer_ts_data
     }
 
     /// Get the next key-value pair, in backward order.
@@ -143,8 +149,10 @@ impl<S: Snapshot> BackwardKvScanner<S> {
                             let lock_value = self.lock_cursor.value(&mut self.statistics.lock);
                             Lock::parse(lock_value)?
                         };
-                        if lock.ts > self.cfg.ts && self.cfg.check_can_be_cached {
-                            self.can_be_cached = false;
+                        if lock.ts > self.cfg.ts
+                            && self.met_newer_ts_data == NewerTsCheckState::NotMetYet
+                        {
+                            self.met_newer_ts_data = NewerTsCheckState::Met;
                         }
                         result = lock
                             .check_ts_conflict(&current_user_key, ts, &self.cfg.bypass_locks)
@@ -214,8 +222,8 @@ impl<S: Snapshot> BackwardKvScanner<S> {
                 } else if last_checked_commit_ts > ts {
                     // Meet an unwanted version, use `last_version` as the return as well.
                     is_done = true;
-                    if self.cfg.check_can_be_cached {
-                        self.can_be_cached = false;
+                    if self.met_newer_ts_data == NewerTsCheckState::NotMetYet {
+                        self.met_newer_ts_data = NewerTsCheckState::Met;
                     }
                 }
             }
@@ -236,17 +244,16 @@ impl<S: Snapshot> BackwardKvScanner<S> {
         // At this time, we must have current commit_ts <= ts. If commit_ts == ts,
         // we don't need to seek any more and we can just utilize `last_version`.
         if last_checked_commit_ts == ts {
-            if self.cfg.check_can_be_cached && self.can_be_cached {
+            if self.met_newer_ts_data == NewerTsCheckState::NotMetYet {
+                // move cursor backward again to check whether there are larger ts.
                 self.write_cursor.prev(&mut self.statistics.write);
-                if let Ok(true) = self.write_cursor.valid() {
+                if self.write_cursor.valid()? {
                     let current_key = self.write_cursor.key(&mut self.statistics.write);
                     if Key::is_user_key_eq(current_key, user_key.as_encoded().as_slice()) {
-                        self.can_be_cached = false;
+                        self.met_newer_ts_data = NewerTsCheckState::Met;
                     } else {
                         *met_prev_user_key = true;
                     }
-                } else {
-                    *met_prev_user_key = true;
                 }
             }
             return Ok(self.handle_last_version(last_version, user_key)?);
@@ -256,34 +263,35 @@ impl<S: Snapshot> BackwardKvScanner<S> {
         // After several `prev()`, we still not get the latest version for the specified ts,
         // use seek to locate the latest version.
 
-        // `user_key` must have reserved space here, so its clone has reserved space too. So no
-        // reallocation happens in `append_ts`.
-
-        // Check newer data if we need to do check_can_be_cached
+        // Check whether newer version exists.
         let mut use_near_seek = false;
-        if self.cfg.check_can_be_cached && self.can_be_cached {
-            let seek_key = user_key.clone().append_ts(TimeStamp::max());
+        let mut seek_key = user_key.clone();
+
+        if self.met_newer_ts_data == NewerTsCheckState::NotMetYet {
+            seek_key = seek_key.append_ts(TimeStamp::max());
             self.write_cursor
                 .internal_seek(&seek_key, &mut self.statistics.write)?;
-            use_near_seek = true;
             assert!(self.write_cursor.valid()?);
+            seek_key = seek_key.truncate_ts()?;
+            use_near_seek = true;
+
             let current_key = self.write_cursor.key(&mut self.statistics.write);
-            assert!(Key::is_user_key_eq(
+            debug_assert!(Key::is_user_key_eq(
                 current_key,
                 user_key.as_encoded().as_slice()
             ));
-            let max_ts = Key::decode_ts_from(current_key)?;
-            if max_ts > ts {
-                self.can_be_cached = false
+            let key_ts = Key::decode_ts_from(current_key)?;
+            if key_ts > ts {
+                self.met_newer_ts_data = NewerTsCheckState::Met
             }
         }
 
-        let seek_key = user_key.clone().append_ts(ts);
-
-        // TODO: Replace by cast + seek().
+        // `user_key` must have reserved space here, so its clone `seek_key` has reserved space
+        // too. Thus no reallocation happens in `append_ts`.
+        seek_key = seek_key.append_ts(ts);
         if use_near_seek {
             self.write_cursor
-                .near_seek_for_prev(&seek_key, &mut self.statistics.write)?;
+                .near_seek(&seek_key, &mut self.statistics.write)?;
         } else {
             self.write_cursor
                 .internal_seek(&seek_key, &mut self.statistics.write)?;
@@ -297,7 +305,7 @@ impl<S: Snapshot> BackwardKvScanner<S> {
             let current_ts = {
                 let current_key = self.write_cursor.key(&mut self.statistics.write);
                 // We should never reach another user key.
-                assert!(Key::is_user_key_eq(
+                debug_assert!(Key::is_user_key_eq(
                     current_key,
                     user_key.as_encoded().as_slice()
                 ));

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -90,7 +90,7 @@ futures-cpupool = "0.1"
 futures03 = { package = "futures", version = "0.3", features = ["executor"] }
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/innerr/kvproto.git", default-features = false, branch = "issue-6690" }
 pd_client = { path = "../components/pd_client" }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/tests/benches/misc/storage/incremental_get.rs
+++ b/tests/benches/misc/storage/incremental_get.rs
@@ -40,6 +40,7 @@ fn table_lookup_gen_data() -> (SnapshotStore<RocksSyncSnapshot>, Vec<Key>) {
         IsolationLevel::Si,
         true,
         Default::default(),
+        false,
     );
 
     // Keys are given in order, and are far away from each other to simulate a normal table lookup
@@ -67,7 +68,7 @@ fn bench_table_lookup_mvcc_incremental_get(b: &mut Bencher) {
     let (mut store, keys) = table_lookup_gen_data();
     b.iter(|| {
         for key in &keys {
-            black_box(store.incremental_get(key, None).unwrap());
+            black_box(store.incremental_get(key).unwrap());
         }
     })
 }

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -72,9 +72,10 @@ fn reversed_checksum_crc64_xor<E: Engine>(store: &Store<E>, range: KeyRange) -> 
         IsolationLevel::Si,
         true,
         Default::default(),
+        false,
     );
     let mut scanner = RangesScanner::new(RangesScannerOptions {
-        storage: TiKVStorage::from(store),
+        storage: TiKVStorage::new(store, false),
         ranges: vec![Range::from_pb_range(range, false)],
         scan_backward_in_range: true,
         is_key_only: false,


### PR DESCRIPTION
- Changed name in Storage to: `check_has_newer_ts_data`, `met_newer_ts_data` to avoid introducing Coprocessor concepts to the storage layer.

- Reuse key buffer to avoid building key twice in some scenarios.

- Move `can_be_cached` of point getter from parameter list to structure to make it simple.

- Merged `check_can_be_cached` and `can_be_cached` together using a enum `NewerTsCheckState { Unknown, NotMetYet, Met }`

- Fixed a unit test in `src/storage/mvcc/reader/scanner/mod.rs`