### PR TITLE
Fake PR just for review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,7 +3030,7 @@ dependencies = [
 [[package]]
 name = "raft"
 version = "0.6.0-alpha"
-source = "git+https://github.com/pingcap/raft-rs#2d721a6b054480839fb2212eb77c6465fdae8991"
+source = "git+https://github.com/innerr/raft-rs?branch=ssd#03b9df4e126ad97d4cc6a70994dc4e72e76ffe66"
 dependencies = [
  "fxhash",
  "getset",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.6.0-alpha"
-source = "git+https://github.com/pingcap/raft-rs#2d721a6b054480839fb2212eb77c6465fdae8991"
+source = "git+https://github.com/innerr/raft-rs?branch=ssd#03b9df4e126ad97d4cc6a70994dc4e72e76ffe66"
 dependencies = [
  "lazy_static",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,8 +182,8 @@ zipf = "6.1.0"
 
 [patch.crates-io]
 # TODO: remove this when new raft-rs is published.
-raft = { git = "https://github.com/pingcap/raft-rs", branch = "master", default-features = false }
-raft-proto = { git = "https://github.com/pingcap/raft-rs", branch = "master", default-features = false }
+raft = { git = "https://github.com/innerr/raft-rs", branch = "ssd", default-features = false }
+raft-proto = { git = "https://github.com/innerr/raft-rs", branch = "ssd", default-features = false }
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev = "b67d432c1b74350b38a5d96ddf885ac6c3ff46f5" }
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "b67d432c1b74350b38a5d96ddf885ac6c3ff46f5" }
 fail = { git = "https://github.com/tikv/fail-rs.git", rev = "2cf1175a1a5cc2c70bd20ebd45313afd69b558fc" }

--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -227,7 +227,11 @@ pub trait PollHandler<N, C> {
     fn end(&mut self, batch: &mut [Box<N>]);
 
     /// This function is called when batch system is going to sleep.
-    fn pause(&mut self) {}
+    /// If the FSM still have works to do, it will return false to inform
+    /// the poller.
+    fn pause(&mut self) -> bool {
+        true
+    }
 }
 
 /// Internal poller that fetches batch and call handler hooks for readiness.
@@ -256,9 +260,16 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
         }
 
         if batch.is_empty() {
-            self.handler.pause();
-            if let Ok(fsm) = self.fsm_receiver.recv() {
-                return batch.push(fsm);
+            loop {
+                if self.handler.pause() {
+                    if let Ok(fsm) = self.fsm_receiver.recv() {
+                        return batch.push(fsm);
+                    }
+                } else {
+                    if let Ok(fsm) = self.fsm_receiver.recv_timeout(Duration::from_nanos(100000)) {
+                        return batch.push(fsm);
+                    }
+                }
             }
         }
         !batch.is_empty()

--- a/components/raftstore/src/lib.rs
+++ b/components/raftstore/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(cell_update)]
 #![feature(shrink_to)]
 #![feature(div_duration)]
+#![feature(thread_id_value)]
 
 #[macro_use]
 extern crate bitflags;

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -28,7 +28,7 @@ with_prefix!(prefix_store "store-");
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     // true for high reliability, prevent data loss when power failure.
-    pub sync_log: bool,
+    pub delay_sync_ns: u64,
     // minimizes disruption when a partitioned node rejoins the cluster by using a two phase election.
     #[config(skip)]
     pub prevote: bool,
@@ -196,7 +196,7 @@ impl Default for Config {
     fn default() -> Config {
         let split_size = ReadableSize::mb(coprocessor::config::SPLIT_SIZE_MB);
         Config {
-            sync_log: true,
+            delay_sync_ns: 0,
             prevote: true,
             raftdb_path: String::new(),
             capacity: ReadableSize(0),
@@ -415,10 +415,14 @@ impl Config {
         Ok(())
     }
 
+    pub fn delay_sync_enabled(&self) -> bool {
+        self.delay_sync_ns != 0
+    }
+
     pub fn write_into_metrics(&self) {
         CONFIG_RAFTSTORE_GAUGE
-            .with_label_values(&["sync_log"])
-            .set((self.sync_log as i32).into());
+            .with_label_values(&["delay_sync_ns"])
+            .set((self.delay_sync_ns as i32).into());
         CONFIG_RAFTSTORE_GAUGE
             .with_label_values(&["prevote"])
             .set((self.prevote as i32).into());

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -320,12 +320,11 @@ where
     kv_wb: Option<W>,
     kv_wb_last_bytes: u64,
     kv_wb_last_keys: u64,
+    sync_kvdb_count: u64,
 
     last_applied_index: u64,
     committed_count: usize,
 
-    // Indicates that WAL can be synchronized when data is written to KV engine.
-    enable_sync_log: bool,
     // Whether synchronize WAL is preferred.
     sync_log_hint: bool,
     // Whether to use the delete range API instead of deleting one by one.
@@ -373,9 +372,9 @@ where
             apply_res: vec![],
             kv_wb_last_bytes: 0,
             kv_wb_last_keys: 0,
+            sync_kvdb_count: 0,
             last_applied_index: 0,
             committed_count: 0,
-            enable_sync_log: cfg.sync_log,
             sync_log_hint: false,
             exec_ctx: None,
             use_delete_range: cfg.use_delete_range,
@@ -418,6 +417,7 @@ where
             self.kv_wb = Some(kv_wb);
             self.kv_wb_last_bytes = 0;
             self.kv_wb_last_keys = 0;
+            self.sync_kvdb_count = 0;
         }
     }
 
@@ -447,7 +447,7 @@ where
     /// Writes all the changes into RocksDB.
     /// If it returns true, all pending writes are persisted in engines.
     pub fn write_to_db(&mut self) -> bool {
-        let need_sync = self.enable_sync_log && self.sync_log_hint;
+        let need_sync = self.sync_log_hint;
         if self.kv_wb.as_ref().map_or(false, |wb| !wb.is_empty()) {
             let mut write_opts = engine_traits::WriteOptions::new();
             write_opts.set_sync(need_sync);
@@ -456,6 +456,9 @@ where
                 .unwrap_or_else(|e| {
                     panic!("failed to write to engine: {:?}", e);
                 });
+            if need_sync {
+                self.sync_kvdb_count += 1;
+            }
             report_perf_context!(
                 self.perf_context_statistics,
                 APPLY_PERF_CONTEXT_TIME_HISTOGRAM_STATIC
@@ -2604,7 +2607,7 @@ where
     },
     #[cfg(any(test, feature = "testexport"))]
     #[allow(clippy::type_complexity)]
-    Validate(u64, Box<dyn FnOnce((*const u8, bool)) + Send>),
+    Validate(u64, Box<dyn FnOnce(&ApplyDelegate<EK>) + Send>),
 }
 
 impl<EK> Msg<EK>
@@ -3103,10 +3106,7 @@ where
                     cb,
                 }) => self.handle_change(apply_ctx, cmd, region_epoch, cb),
                 #[cfg(any(test, feature = "testexport"))]
-                Some(Msg::Validate(_, f)) => {
-                    let delegate: *const u8 = unsafe { std::mem::transmute(&self.delegate) };
-                    f((delegate, apply_ctx.enable_sync_log))
-                }
+                Some(Msg::Validate(_, f)) => f(&self.delegate),
                 None => break,
             }
         }
@@ -3196,7 +3196,6 @@ where
                 }
                 _ => {}
             }
-            self.apply_ctx.enable_sync_log = incoming.sync_log;
         }
         self.apply_ctx.perf_context_statistics.start();
     }
@@ -3610,8 +3609,7 @@ mod tests {
             region_id,
             Msg::Validate(
                 region_id,
-                Box::new(move |(delegate, _): (*const u8, _)| {
-                    let delegate = unsafe { &*(delegate as *const ApplyDelegate<RocksEngine>) };
+                Box::new(move |delegate: &ApplyDelegate<RocksEngine>| {
                     validate(delegate);
                     validate_tx.send(()).unwrap();
                 }),

--- a/components/raftstore/src/store/fsm/mod.rs
+++ b/components/raftstore/src/store/fsm/mod.rs
@@ -8,6 +8,7 @@ pub mod apply;
 mod metrics;
 mod peer;
 pub mod store;
+pub mod sync_policy;
 
 pub use self::apply::{
     create_apply_batch_system, Apply, ApplyBatchSystem, ApplyMetrics, ApplyRes, ApplyRouter,

--- a/components/raftstore/src/store/fsm/sync_policy.rs
+++ b/components/raftstore/src/store/fsm/sync_policy.rs
@@ -1,0 +1,494 @@
+// Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::cmp::{self};
+use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicI64, AtomicU64};
+use std::sync::Arc;
+use std::{thread, u64};
+
+use engine_traits::KvEngine;
+use engine_traits::RaftEngine;
+use kvproto::raft_serverpb::RaftMessage;
+use raft::eraftpb::MessageType;
+
+use tikv_util::collections::HashMap;
+use tikv_util::collections::HashSet;
+use tikv_util::time::Instant as TiInstant;
+
+use crate::store::fsm::peer::PeerFsm;
+use crate::store::fsm::RaftRouter;
+use crate::store::local_metrics::SyncEventMetrics;
+use crate::store::transport::Transport;
+use crate::store::util::timespec_to_nanos;
+use crate::store::{PeerMsg, PeerMsgTrivialInfo};
+use crate::Result;
+
+/// This class is for control the raft-engine wal 'sync' policy.
+/// When regions received data, the 'sync' will be holded until reach the deadline,
+/// so the related raft-msgs and region-sync-notifications will be cached and delayed.
+/// After that, when 'sync' is called by any thread later,
+/// the delayed msgs and notifications will be sent and flushed
+pub struct SyncPolicy<EK: KvEngine, ER: RaftEngine, T> {
+    pub trans: DelayableTransport<EK, ER, T>,
+    pub metrics: SyncEventMetrics,
+    raft_engine: ER,
+    router: RaftRouter<EK, ER>,
+    delay_sync_enabled: bool,
+    delay_sync_ns: i64,
+    thread_id: u64,
+
+    /// The global-variables are for cooperate with other poll-worker threads.
+    global_plan_sync_ts: Arc<AtomicI64>,
+    global_plan_sync_id: Arc<AtomicU64>,
+    global_last_sync_ts: Arc<AtomicI64>,
+
+    /// Mark the last-sync-time of this thread, for checking other threads did 'sync' or not.
+    local_last_sync_ts: i64,
+
+    /// Store the unsynced regions, notify them when 'sync' is triggered and finished.
+    /// The map contains: <region_id, (last_index, map_entry_created_time)>
+    unsynced_regions: HashMap<u64, (u64, i64)>,
+
+    /// The poll-round variables are for avoid doing things already did this round.
+    current_round_sync_log: bool,
+    current_round_synced_regions: HashSet<u64>,
+}
+
+impl<EK: KvEngine, ER: RaftEngine, T: Transport> SyncPolicy<EK, ER, T> {
+    pub fn new(
+        raft_engine: ER,
+        router: RaftRouter<EK, ER>,
+        trans: T,
+        delay_sync_enabled: bool,
+        delay_sync_ns: u64,
+    ) -> SyncPolicy<EK, ER, T> {
+        let current_ts = timespec_to_nanos(TiInstant::now_coarse());
+        SyncPolicy {
+            trans: DelayableTransport::new(trans, router.clone(), delay_sync_enabled),
+            metrics: SyncEventMetrics::default(),
+            raft_engine,
+            router,
+            delay_sync_ns: delay_sync_ns as i64,
+            thread_id: 0,
+            global_plan_sync_ts: Arc::new(AtomicI64::new(0)),
+            global_plan_sync_id: Arc::new(AtomicU64::new(0)),
+            global_last_sync_ts: Arc::new(AtomicI64::new(current_ts)),
+            delay_sync_enabled,
+            local_last_sync_ts: current_ts,
+            current_round_sync_log: false,
+            unsynced_regions: HashMap::default(),
+            current_round_synced_regions: HashSet::default(),
+        }
+    }
+
+    pub fn clone(&self) -> SyncPolicy<EK, ER, T> {
+        SyncPolicy {
+            trans: self.trans.clone(),
+            metrics: SyncEventMetrics::default(),
+            raft_engine: self.raft_engine.clone(),
+            router: self.router.clone(),
+            delay_sync_enabled: self.delay_sync_enabled,
+            delay_sync_ns: self.delay_sync_ns,
+            thread_id: 0,
+            global_plan_sync_ts: self.global_plan_sync_ts.clone(),
+            global_plan_sync_id: self.global_plan_sync_id.clone(),
+            global_last_sync_ts: self.global_last_sync_ts.clone(),
+            local_last_sync_ts: self.global_last_sync_ts.load(Ordering::Relaxed),
+            current_round_sync_log: false,
+            unsynced_regions: HashMap::default(),
+            current_round_synced_regions: HashSet::default(),
+        }
+    }
+
+    /// When store fsm begins a new round, clear the round-status and return should-sync
+    pub fn on_begin_check_should_sync(&mut self) -> bool {
+        if !self.delay_sync_enabled {
+            return true;
+        }
+        if self.thread_id == 0 {
+            self.thread_id = thread::current().id().as_u64().get();
+        }
+        self.try_flush_delayed_when_others_synced();
+        self.current_round_synced_regions.clear();
+        let current_ts = timespec_to_nanos(TiInstant::now_coarse());
+        self.current_round_sync_log = self.check_sync_by_deadline_and_cached_count(current_ts);
+        self.current_round_sync_log
+    }
+
+    /// When peer msgs had all handled and before collecting ready,
+    /// If we know it will be sync later, the raft.synced_index could be advanced,
+    /// (even though we doesn't sync yet),
+    /// and the related readiness will be collected in this round, just as without sync-control.
+    pub fn post_peer_msgs_handled(&mut self, peer: &mut PeerFsm<EK, ER>) {
+        if !self.delay_sync_enabled {
+            peer.peer.on_synced(None);
+            return;
+        }
+        let region_id = peer.peer.region().get_id();
+        if self.current_round_sync_log {
+            peer.peer.on_synced(None);
+            self.mark_region_synced(&region_id);
+        } else {
+            let idx = peer.peer.raft_group.raft.raft_log.last_index();
+            self.mark_region_unsync(region_id, idx);
+        }
+    }
+
+    /// The collect_ready might change ctx.sync_log to true, so we need to check the flag again,
+    /// in this case, the synced_index of peers could be advanced now, (sync was call in this round)
+    /// but the related readiness will be collected and handled in next round
+    pub fn post_sync_handle_ready(
+        &mut self,
+        peer: &mut PeerFsm<EK, ER>,
+        sync_log: bool,
+        region_id: u64,
+    ) {
+        if !self.delay_sync_enabled {
+            return;
+        }
+        if !sync_log || self.current_round_synced_regions.contains(&region_id) {
+            return;
+        }
+        peer.peer.on_synced(None);
+        self.mark_region_synced(&region_id);
+        // TODO: may genarate committed_entries, could collect ready from this peer now
+    }
+
+    /// Update metrics and status after the sync time point (whether did sync or not)
+    pub fn post_sync_time_point(&mut self, before_sync_ts: i64, did_sync: bool) {
+        if did_sync {
+            self.metrics.sync_events.sync_raftdb_count += 1;
+            if self.current_round_sync_log {
+                // The other sync reasons already put into metrics
+                self.metrics.sync_events.sync_raftdb_reach_deadline += 1;
+            }
+        } else {
+            self.metrics.sync_events.raftdb_skipped_sync_count += 1;
+        }
+        if !self.delay_sync_enabled || !did_sync {
+            return;
+        }
+        self.update_status_after_synced(before_sync_ts);
+    }
+
+    /// Check and try to flush, it's called when: no 'ready' comes, but we should check flush.
+    /// return bool: all synced and flushed
+    pub fn before_pause_try_sync_and_flush(&mut self) -> bool {
+        if !self.delay_sync_enabled {
+            return true;
+        }
+
+        // current_round_sync_log is true means all data of this round are synced and flushed.
+        // but false doesn't means not sync, ctx.sync_log might be changed during ready handling,
+        // so we still need to check the deadline when it's false.
+        if self.current_round_sync_log {
+            return true;
+        }
+
+        if self.trans.delayed_count() == 0 && self.unsynced_regions.is_empty() {
+            return true;
+        }
+
+        let last_sync_ts = self.global_last_sync_ts.load(Ordering::Relaxed);
+        let plan_sync_ts = self.global_plan_sync_ts.load(Ordering::Relaxed);
+        if last_sync_ts < plan_sync_ts {
+            // Other thread is planning to sync, so this thread should do nothing
+            return false;
+        }
+
+        let current_ts = timespec_to_nanos(TiInstant::now_coarse());
+        let elapsed = cmp::max(current_ts - last_sync_ts, 0);
+        self.metrics
+            .thread_check_result
+            .observe(elapsed as f64 / 1e9);
+
+        if elapsed > self.delay_sync_ns {
+            if let Err(e) = self.raft_engine.sync() {
+                warn!("raftdb.sync_wal() failed"; "error" => ?e);
+                return false;
+            }
+            self.metrics.sync_events.sync_raftdb_count += 1;
+            self.metrics.sync_events.sync_raftdb_reach_deadline_no_ready += 1;
+            self.update_status_after_synced(current_ts)
+        } else {
+            self.try_flush_delayed_when_others_synced()
+        }
+    }
+
+    /// Store the plan-to-sync time to global, so that other threads could avoid unnecessary sync
+    pub fn mark_plan_to_sync(&self, current_ts: i64) {
+        if !self.delay_sync_enabled {
+            return;
+        }
+        self.global_plan_sync_id
+            .store(self.thread_id, Ordering::Relaxed);
+        // Store the max plan_sync_ts of all threads,
+        // it's ok if other thread rewrite global_plan_sync_ts in the read-write gap
+        let plan_sync_ts = self.global_plan_sync_ts.load(Ordering::Relaxed);
+        self.global_plan_sync_ts
+            .store(cmp::max(current_ts, plan_sync_ts), Ordering::Relaxed);
+    }
+
+    /// Update the global and thread-local status(last_sync_ts, last_sync_id, etc),
+    /// all received data which were cached before 'before_sync_ts' is well persisted now,
+    /// so this function also flush the related delayed content.
+    /// Return: all flushed
+    fn update_status_after_synced(&mut self, before_sync_ts: i64) -> bool {
+        if !self.delay_sync_enabled {
+            return true;
+        }
+        let all_flushed = self.flush_delayed_on_synced(before_sync_ts, true);
+        self.local_last_sync_ts = before_sync_ts;
+        let prev_last_sync_ts = self
+            .global_last_sync_ts
+            .swap(before_sync_ts, Ordering::Relaxed);
+        let elapsed = cmp::max(before_sync_ts - prev_last_sync_ts, 0);
+        self.metrics.sync_log_interval.observe(elapsed as f64 / 1e9);
+        all_flushed
+    }
+
+    /// Return bool: all flushed
+    fn try_flush_delayed_when_others_synced(&mut self) -> bool {
+        if self.trans.delayed_count() == 0 && self.unsynced_regions.is_empty() {
+            return true;
+        }
+        let last_sync_ts = self.global_last_sync_ts.load(Ordering::Relaxed);
+        if self.local_last_sync_ts < last_sync_ts {
+            self.local_last_sync_ts = last_sync_ts;
+            self.flush_delayed_on_synced(last_sync_ts, false)
+        } else {
+            false
+        }
+    }
+
+    /// Check this thread should call sync or not,
+    /// if current_ts is close to last_sync_ts, or other threads are plan to sync,
+    /// then this thread should not sync.
+    fn check_sync_by_deadline_and_cached_count(&mut self, current_ts: i64) -> bool {
+        if self.trans.delayed_count() > 1024 || self.unsynced_regions.len() > 256 {
+            self.metrics.sync_events.sync_raftdb_delay_cache_is_full += 1;
+            return true;
+        }
+        let mut last_or_plan_sync_ts = self.global_last_sync_ts.load(Ordering::Relaxed);
+        //let plan_sync_id = self.global_plan_sync_id.load(Ordering::Relaxed);
+        //if plan_sync_id != self.thread_id {
+        let plan_sync_ts = self.global_plan_sync_ts.load(Ordering::Relaxed);
+        last_or_plan_sync_ts = cmp::max(last_or_plan_sync_ts, plan_sync_ts);
+        //}
+        let elapsed = cmp::max(current_ts - last_or_plan_sync_ts, 0);
+        self.metrics
+            .thread_check_result
+            .observe(elapsed as f64 / 1e9);
+        elapsed > self.delay_sync_ns
+    }
+
+    /// Return bool: all flushed
+    fn flush_delayed_on_synced(&mut self, synced_ts: i64, flush_all: bool) -> bool {
+        let all_sent = self
+            .trans
+            .send_delayed(synced_ts, flush_all, &mut self.metrics);
+
+        let mut unsynced_regions: HashMap<u64, (u64, i64)> = HashMap::default();
+        for (region_id, (idx, ts)) in self.unsynced_regions.drain() {
+            let delay_duration = synced_ts - ts;
+            if !flush_all && delay_duration <= 0 {
+                unsynced_regions.insert(region_id, (idx, ts));
+                continue;
+            }
+            self.metrics
+                .sync_delay_duration
+                .observe(delay_duration as f64 / 1e9);
+            let res = self.router.send(region_id, PeerMsg::Synced(idx));
+            if let Err(e) = res {
+                error!(
+                    "flush_delayed_on_synced failed";
+                    "unsynced_region_id" => region_id,
+                    "notify_index" => idx,
+                    "err" => ?e,
+                );
+                unsynced_regions.insert(region_id, (idx, ts));
+            }
+        }
+        if !unsynced_regions.is_empty() {
+            self.unsynced_regions = unsynced_regions;
+        }
+        all_sent && self.unsynced_regions.is_empty()
+    }
+
+    #[inline]
+    fn mark_region_unsync(&mut self, region_id: u64, idx: u64) {
+        assert!(!self.current_round_sync_log);
+        let current_ts = timespec_to_nanos(TiInstant::now_coarse());
+        self.unsynced_regions.insert(region_id, (idx, current_ts));
+    }
+
+    #[inline]
+    fn mark_region_synced(&mut self, region_id: &u64) {
+        self.unsynced_regions.remove(region_id);
+    }
+}
+
+pub struct DelayableTransport<EK, ER, T>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+{
+    trans: T,
+    router: RaftRouter<EK, ER>,
+    delayed: Vec<(RaftMessage, PeerMsgTrivialInfo)>,
+    delay_sync_enabled: bool,
+}
+
+impl<EK, ER, T: Transport> DelayableTransport<EK, ER, T>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+{
+    pub fn new(
+        trans: T,
+        router: RaftRouter<EK, ER>,
+        delay_sync_enabled: bool,
+    ) -> DelayableTransport<EK, ER, T> {
+        DelayableTransport {
+            trans,
+            router,
+            delayed: vec![],
+            delay_sync_enabled,
+        }
+    }
+
+    pub fn delayed_count(&self) -> usize {
+        self.delayed.len()
+    }
+
+    /// Return bool: all sent
+    pub fn send_delayed(
+        &mut self,
+        synced_ts: i64,
+        send_all: bool,
+        metrics: &mut SyncEventMetrics,
+    ) -> bool {
+        if !self.delay_sync_enabled {
+            return true;
+        }
+        if self.delayed.is_empty() {
+            return true;
+        }
+        let mut delayed: Vec<(RaftMessage, PeerMsgTrivialInfo)> = vec![];
+        for (msg, info) in self.delayed.drain(..) {
+            let delay_duration = synced_ts - info.create_ts;
+            if !send_all && delay_duration <= 0 {
+                delayed.push((msg, info));
+                continue;
+            }
+            metrics
+                .msg_delay_duration
+                .observe(delay_duration as f64 / 1e9);
+            let region_id = msg.get_region_id();
+            let from_peer_id = msg.get_from_peer().get_id();
+            let to_peer_id = msg.get_to_peer().get_id();
+            let res = self.trans.send(msg);
+            if let Err(err) = res {
+                warn!(
+                    "failed to send to other peer from transport delayed cache";
+                    "region_id" => region_id,
+                    "peer_id" => from_peer_id,
+                    "target_peer_id" => to_peer_id,
+                    "err" => ?err,
+                );
+                self.router
+                    .send(region_id, PeerMsg::AsyncSendMsgFailed(info))
+                    .unwrap();
+            }
+        }
+        self.trans.flush();
+        if !delayed.is_empty() {
+            self.delayed = delayed;
+        }
+        self.delayed.is_empty()
+    }
+}
+
+impl<EK, ER, T: Transport> Transport for DelayableTransport<EK, ER, T>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+{
+    fn send(&mut self, msg: RaftMessage) -> Result<()> {
+        self.trans.send(msg)
+    }
+
+    fn flush(&mut self) {
+        self.trans.flush()
+    }
+}
+
+impl<EK, ER, T: Transport> Clone for DelayableTransport<EK, ER, T>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+{
+    fn clone(&self) -> DelayableTransport<EK, ER, T> {
+        DelayableTransport::new(
+            self.trans.clone(),
+            self.router.clone(),
+            self.delay_sync_enabled,
+        )
+    }
+}
+
+unsafe impl<EK, ER, T: Transport> Send for DelayableTransport<EK, ER, T>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+{
+}
+
+pub trait DelayableSender {
+    fn maybe_delay_send(
+        &mut self,
+        msg: RaftMessage,
+        from_leader: bool,
+        to_leader: bool,
+        is_snapshot_msg: bool,
+    ) -> Result<()>;
+}
+
+impl<EK, ER, T: Transport> DelayableSender for DelayableTransport<EK, ER, T>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+{
+    fn maybe_delay_send(
+        &mut self,
+        msg: RaftMessage,
+        from_leader: bool,
+        to_leader: bool,
+        is_snapshot_msg: bool,
+    ) -> Result<()> {
+        if !self.delay_sync_enabled {
+            return self.trans.send(msg);
+        }
+        if from_leader {
+            return self.trans.send(msg);
+        }
+
+        // TODO: direct-send more messages that not depend on syncing
+        let msg_type = msg.get_message().get_msg_type();
+        if msg_type == MessageType::MsgHeartbeat || msg_type == MessageType::MsgHeartbeatResponse {
+            self.trans.send(msg)
+        } else {
+            let to_peer_id = msg.get_to_peer().get_id();
+            self.delayed.push((
+                msg,
+                PeerMsgTrivialInfo {
+                    create_ts: timespec_to_nanos(TiInstant::now_coarse()),
+                    to_leader,
+                    is_snapshot_msg,
+                    to_peer_id,
+                },
+            ));
+            Ok(())
+        }
+    }
+}

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -465,6 +465,38 @@ lazy_static! {
         "Total memory size of raft entries caches."
         ).unwrap();
 
+    pub static ref SYNC_EVENTS: IntCounterVec =
+        register_int_counter_vec!(
+            "tikv_raftstore_sync_events",
+            "Counts of raftstore sync events.",
+            &["event"]
+        )
+        .unwrap();
+    pub static ref PEER_SYNC_LOG_INTERVAL_HISTOGRAM: Histogram =
+        register_histogram!(
+            "tikv_raftstore_sync_log_interval_seconds",
+            "Bucketed histogram of sync log interval",
+            exponential_buckets(0.0001, 2.0, 20).unwrap()
+        ).unwrap();
+    pub static ref PEER_MSG_DELAY_HISTOGRAM: Histogram =
+        register_histogram!(
+            "tikv_raftstore_msg_delay_seconds",
+            "Bucketed histogram of sync log in idle stat interval",
+            exponential_buckets(0.0001, 2.0, 20).unwrap()
+        ).unwrap();
+    pub static ref PEER_THREAD_CHECK_SYNC_RESULT_HISTOGRAM: Histogram =
+        register_histogram!(
+            "tikv_raftstore_thread_check_sync_result_seconds",
+            "Bucketed histogram of sync log in idle stat interval",
+            exponential_buckets(0.0001, 2.0, 20).unwrap()
+        ).unwrap();
+    pub static ref PEER_SYNC_DELAY_HISTOGRAM: Histogram =
+        register_histogram!(
+            "tikv_raftstore_sync_delay_seconds",
+            "Bucketed histogram of sync delay seconds",
+            exponential_buckets(0.0001, 2.0, 20).unwrap()
+        ).unwrap();
+
     pub static ref APPLY_PENDING_BYTES_GAUGE: IntGauge = register_int_gauge!(
         "tikv_raftstore_apply_pending_bytes",
         "The bytes pending in the channel of apply FSMs."

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -27,8 +27,8 @@ pub use self::bootstrap::{
 pub use self::config::Config;
 pub use self::fsm::{DestroyPeerJob, RaftRouter, StoreInfo};
 pub use self::msg::{
-    Callback, CasualMessage, MergeResultKind, PeerMsg, PeerTicks, RaftCommand, ReadCallback,
-    ReadResponse, SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
+    Callback, CasualMessage, MergeResultKind, PeerMsg, PeerMsgTrivialInfo, PeerTicks, RaftCommand,
+    ReadCallback, ReadResponse, SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
 };
 pub use self::peer::{
     AbstractPeer, Peer, PeerStat, ProposalContext, RequestInspector, RequestPolicy,

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -18,6 +18,7 @@ use time::{Duration, Timespec};
 
 use super::peer_storage;
 use crate::{Error, Result};
+use tikv_util::time::Instant;
 use tikv_util::Either;
 
 pub fn find_peer(region: &metapb::Region, store_id: u64) -> Option<&metapb::Peer> {
@@ -605,6 +606,17 @@ fn timespec_to_u64(ts: Timespec) -> u64 {
     let ms = ts.nsec >> TIMESPEC_NSEC_SHIFT;
     let sec = ts.sec << TIMESPEC_SEC_SHIFT;
     sec as u64 | ms as u64
+}
+
+#[inline]
+pub fn timespec_to_nanos(ins: Instant) -> i64 {
+    let ts = match ins {
+        Instant::Monotonic(ts) => ts,
+        Instant::MonotonicCoarse(ts) => ts,
+    };
+    assert!(ts.sec >= 0 && ts.sec < (1i64 << (64 - TIMESPEC_SEC_SHIFT)));
+    assert!(ts.nsec >= 0);
+    ts.sec * 1_000_000_000 + ts.nsec as i64
 }
 
 /// Convert Timespec to u64.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2934,7 +2934,6 @@ mod tests {
         let mut incoming = TiKvConfig::default();
         incoming.coprocessor.region_split_keys = 10000;
         incoming.gc.max_write_bytes_per_sec = ReadableSize::mb(100);
-        incoming.raft_store.sync_log = false;
         incoming.rocksdb.defaultcf.block_cache_size = ReadableSize::mb(500);
         let diff = old.diff(&incoming);
         let mut change = HashMap::new();

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -128,24 +128,6 @@ where
     rx.recv_timeout(Duration::from_secs(3)).unwrap();
 }
 
-fn validate_apply<F>(router: &ApplyRouter<RocksEngine>, region_id: u64, validate: F)
-where
-    F: FnOnce(bool) + Send + 'static,
-{
-    let (tx, rx) = mpsc::channel();
-    router.schedule_task(
-        region_id,
-        ApplyTask::Validate(
-            region_id,
-            Box::new(move |(_, sync_log): (_, bool)| {
-                validate(sync_log);
-                tx.send(()).unwrap();
-            }),
-        ),
-    );
-    rx.recv_timeout(Duration::from_secs(3)).unwrap();
-}
-
 #[test]
 fn test_update_raftstore_config() {
     let (mut config, _dir) = TiKvConfig::with_tmp().unwrap();
@@ -178,7 +160,7 @@ fn test_update_raftstore_config() {
 #[test]
 fn test_update_apply_store_config() {
     let (mut config, _dir) = TiKvConfig::with_tmp().unwrap();
-    config.raft_store.sync_log = true;
+    config.raft_store.messages_per_tick = 4096;
     config.validate().unwrap();
     let (cfg_controller, raft_router, apply_router, mut system) =
         start_raftstore(config.clone(), &_dir);
@@ -190,23 +172,17 @@ fn test_update_apply_store_config() {
     apply_router.schedule_task(region_id, ApplyTask::Registration(reg));
 
     validate_store(&raft_router, move |cfg: &Config| {
-        assert_eq!(cfg.sync_log, true);
-    });
-    validate_apply(&apply_router, region_id, |sync_log| {
-        assert_eq!(sync_log, true);
+        assert_eq!(cfg.messages_per_tick, 4096);
     });
 
     // dispatch updated config
     cfg_controller
-        .update_config("raftstore.sync-log", "false")
+        .update_config("raftstore.messages-per-tick", "6904")
         .unwrap();
 
     // both configs should be updated
     validate_store(&raft_router, move |cfg: &Config| {
-        assert_eq!(cfg.sync_log, false);
-    });
-    validate_apply(&apply_router, region_id, |sync_log| {
-        assert_eq!(sync_log, false);
+        assert_eq!(cfg.messages_per_tick, 6904);
     });
 
     system.shutdown();

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -137,7 +137,7 @@ fn test_serde_custom_tikv_config() {
     store_batch_system.pool_size = 3;
     store_batch_system.reschedule_duration = ReadableDuration::secs(2);
     value.raft_store = RaftstoreConfig {
-        sync_log: false,
+        delay_sync_ns: 0,
         prevote: false,
         raftdb_path: "/var".to_owned(),
         capacity: ReadableSize(123),


### PR DESCRIPTION
Signed-off-by: Liu Cong <innerr@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Improve TiKV performance on non-NVMe disk.

Problem Summary:

- The 'sync' performance is varied on different types of disk, it could from several hundred to 50K times per sec, we could use `fio -fdatasync` or `pg_test_sync` to profile the 'sync' performance of a disk
- Typically, a non-NVMe disk could perform 2K~5K sync per sec
- When TiKV runs under proper stress (lots of write, disk latency is good), the 'sync' frequency could reach 20K as we discovered on grafana panel

So, the 'sync' performance will be one of the bottlenecks of TiKV performance, especially under some types of disk.
This PR provide a config entry to control the raftstore's 'sync' frequency.

### What is changed and how it works?

When peers receive data, the 'write' operation goes as usual, but the 'sync' will be hold for a while.
(not holding 'write' operation is the key, IO will be smoother comparing to simple batching, which will hold both 'write' and 'sync')

Before 'sync' is called, the related raft follower's messages of `AppendResp` will be blocked(held and cached),
when follower perform 'sync', the raft log will be considered well persisted, then the messages will be released and delivered to leader. 

In current implementation of `raft-rs`, the `committed index` of a `raft group` will advance immediately, even though the log is not persisted yet, because currently it assume that the log will(should, must) be persisted before next round of handling.
This assumption is not fit for our purpose, so we changed `raft-rs` for a bit:
- Added a new method `raft_group.on_synced(index)` to deliver 'sync' event to raft group, the committed index will not advance until on_synced is called.
- Enhanced `raft_group.ready_since(index)` to `raft_group.ready_from_range(index_low, index_high)`, to fetch ready only belong to synced logs.
- PR: https://github.com/innerr/raft-rs/pull/1
- Detail proposal: https://github.com/etcd-io/etcd/issues/12257

### Related changes

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

Side effects

- These changes could delay the committed logs' applying, and cause greater latency, so we provide a config entry to enable/disable it when running TiKV on different types of disk.

### Release note <!-- bugfixes or new feature need a release note -->
- Control sync frequency using config entry: raftstore.delay-sync-ns, performance on some types of disk could be better with this. 
